### PR TITLE
feat: PRプレビュー環境用CSSバナーの追加

### DIFF
--- a/pr-banner.css
+++ b/pr-banner.css
@@ -1,0 +1,26 @@
+/* PR Preview Banner
+ * Displayed on PR preview environments when <body data-pr="N"> is present.
+ * The workflow injects data-pr="N" into <body> tags and links this stylesheet.
+ */
+
+body[data-pr]::before {
+  content: "PR #" attr(data-pr) " のプレビュー環境";
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 2147483647;
+  background: #e8a838;
+  color: #000;
+  font: bold 14px/1 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  padding: 10px 16px;
+  text-align: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  box-sizing: border-box;
+}
+
+/* Push body content down so it isn't hidden under the fixed banner (≈ 40px) */
+body[data-pr] {
+  padding-top: 40px !important;
+}


### PR DESCRIPTION
Closes #16

Resolves issue #16 by adding `pr-banner.css` for PR preview environments.

Adds a fixed orange banner at the top of PR preview pages using `body[data-pr]::before` pseudo-element.
The workflow needs to inject `data-pr="N"` into `<body>` tags and link this stylesheet.

Generated with [Claude Code](https://claude.ai/code)